### PR TITLE
Disable aggressive home reset

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -594,6 +594,8 @@
                     <li onclick="disableElectron19FileOpen = !disableElectron19FileOpen; saveDiagnostics(); location.reload();" id="disableElectron19FileOpenTick"><a href="#"><i class="far fa-folder-open fa-fw"></i> Disable Native File Open
                         Dialog</a>
                     </li>
+                    <li class="divider"></li>
+                    <li onclick="disableAggressiveHomeReset =! disableAggressiveHomeReset; saveDiagnostics(); location.reload();" id="disableAggressiveHomeResetTick"><a href="#"><i class="fas fa-fw fa-home"></i> Disable Aggressive Home Reset</a></li>
 
                 </div>
                 <span class="title">Settings</span>

--- a/app/js/diagnostics.js
+++ b/app/js/diagnostics.js
@@ -18,7 +18,6 @@ function saveDiagnostics() {
   localStorage.setItem('disableDROupdates', disableDROupdates);
   localStorage.setItem('disableElectron19FileOpen', disableElectron19FileOpen);
   localStorage.setItem('disableAggressiveHomeReset', disableAggressiveHomeReset);
-  socket.emit('aggrressiveHomeReset', !disableAggressiveHomeReset);
 }
 
 function initDiagnostics() {
@@ -100,7 +99,6 @@ function initDiagnostics() {
     if (JSON.parse(localStorage.getItem('disableAggressiveHomeReset')) == true) {
       disableAggressiveHomeReset = true;
       $('#disableAggressiveHomeResetTick').addClass("checked");
-      socket.emit('aggrressiveHomeReset', false);
     }
   } else {
     disableAggressiveHomeReset = false;

--- a/app/js/diagnostics.js
+++ b/app/js/diagnostics.js
@@ -6,6 +6,7 @@ var disable3Dgcodepreview = false;
 var disableSerialLog = false; // todo also hide tab when set to true
 var disableDROupdates = false;
 var disableElectron19FileOpen = false;
+var disableAggressiveHomeReset = false;
 
 function saveDiagnostics() {
   localStorage.setItem('disable3Dviewer', disable3Dviewer);
@@ -16,7 +17,8 @@ function saveDiagnostics() {
   localStorage.setItem('disableSerialLog', disableSerialLog);
   localStorage.setItem('disableDROupdates', disableDROupdates);
   localStorage.setItem('disableElectron19FileOpen', disableElectron19FileOpen);
-
+  localStorage.setItem('disableAggressiveHomeReset', disableAggressiveHomeReset);
+  socket.emit('aggrressiveHomeReset', !disableAggressiveHomeReset);
 }
 
 function initDiagnostics() {
@@ -92,6 +94,16 @@ function initDiagnostics() {
     }
   } else {
     disableElectron19FileOpen = false;
+  }
+
+  if (localStorage.getItem('disableAggressiveHomeReset')) {
+    if (JSON.parse(localStorage.getItem('disableAggressiveHomeReset')) == true) {
+      disableAggressiveHomeReset = true;
+      $('#disableAggressiveHomeResetTick').addClass("checked");
+      socket.emit('aggrressiveHomeReset', false);
+    }
+  } else {
+    disableAggressiveHomeReset = false;
   }
 
 };

--- a/app/js/websocket.js
+++ b/app/js/websocket.js
@@ -123,6 +123,7 @@ function initSocket() {
     'timeout': 60000,
     'connect timeout': 60000
   }); // socket.io init
+  socket.emit('aggrressiveHomeReset', !disableAggressiveHomeReset);
   var icon = ''
   var source = "websocket"
   var string = "Bidirectional Websocket Interface Started Succesfully"


### PR DESCRIPTION
The software clears its homing status on every alert, and even when a job is stopped safely. This makes the status basically useless. The change adds a setting in the diagnostics menu, which clears the homing status only for specific alerts (like sudden stop during a move)